### PR TITLE
Re-allow pick Seraphim in lobby

### DIFF
--- a/mods/coop/hook/lua/simInit.lua
+++ b/mods/coop/hook/lua/simInit.lua
@@ -45,7 +45,7 @@ local ReallyBeginSession = BeginSession
 function BeginSession()
     ReallyBeginSession()
 
-    # Hide scores for AI's and make them able to place orders outside the playable rect
+    -- Hide scores for AI's and make them able to place orders outside the playable rect
     for i = 1, table.getn(ArmyBrains) do
         if not table.find(ScenarioInfo.HumanPlayers, i) then
             SetArmyShowScore(i, false)

--- a/mods/coop/hook/lua/ui/lobby/data/playerdata.lua
+++ b/mods/coop/hook/lua/ui/lobby/data/playerdata.lua
@@ -1,3 +1,0 @@
--- Account for the fact we're busy pretending the Seraphim don't exist (hook ordering sadly makes
--- this not be quite as rainbows and sunshine as we wanted)
-DEFAULT_MAPPING.Faction = DEFAULT_MAPPING.Faction - 1

--- a/mods/coop/hook/lua/ui/lobby/lobby.lua
+++ b/mods/coop/hook/lua/ui/lobby/lobby.lua
@@ -1,24 +1,3 @@
--- While we're in the lobby, let's pretend the seraphim don't exist.
--- This elegantly makes absolutely everything - including randomised factions - work correctly.
-local newFactionData = {}
-for index, tbl in FactionData.Factions do
-    if tbl.Key ~= "seraphim" then
-        table.insert(newFactionData, tbl)
-    end
-end
-
-local realFactionData = FactionData.Factions
-FactionData.Factions = newFactionData
-
--- Some extra magic is also needed at launch-time for everyone.
-local GameReallyLaunched = lobbyComm.GameLaunched
-lobbyComm.GameLaunched = function(self)
-    -- Okay, okay, the seraphim really exist. Let's not break anything by keeping this pretense up.
-    FactionData.Factions = realFactionData
-
-    GameReallyLaunched()
-end
-
 -- Do some extra logic at the end of CreateUI to delete some buttons that make no sense.
 local ReallyCreateUI = CreateUI
 function CreateUI()


### PR DESCRIPTION
There is no need to restrict Seraphim in the lobby, with upcoming
Seraphim mission it's welcome change. Reason that in FA you could not
play seraphim is poor, that way we would not allow any faction since in
vanilla campaign you could play just one faction in each mission.
So trying to pick Seraphim into FA campaign is same as picking UEF into
Cybran mission.

In future we could maybe store allowed factions with the map and change
the lobby according to that.
