### PR TITLE
Add support any number of players

### DIFF
--- a/mods/coop/hook/lua/ScenarioFramework.lua
+++ b/mods/coop/hook/lua/ScenarioFramework.lua
@@ -1,7 +1,7 @@
 local FactionData = import('/lua/factions.lua')
 
 function GetLeaderAndLocalFactions()
-    local leaderFactionIndex = GetArmyBrain('Player'):GetFactionIndex()
+    local leaderFactionIndex = GetArmyBrain('Player1'):GetFactionIndex()
     ScenarioInfo.LeaderFaction = FactionData.Factions[leaderFactionIndex].Key
 
     local focusArmy = GetFocusArmy()

--- a/mods/coop/hook/lua/simInit.lua
+++ b/mods/coop/hook/lua/simInit.lua
@@ -1,18 +1,9 @@
-local MapUtil = import('/lua/ui/maputil.lua')
-
--- The "imaginary" armies we synthesise for the coop players.
-local imaginaryArmyList = MapUtil.GetArmies()
-local imaginaryArmySet = {}
-for k, v in imaginaryArmyList do
-    imaginaryArmySet[v] = true
-end
-
 local ReallyOnCreateArmyBrain = OnCreateArmyBrain
 function OnCreateArmyBrain(index, brain, name, nickname)
     ReallyOnCreateArmyBrain(index, brain, name, nickname)
 
     -- Stuff this army into the HumanPlayers set, if applicable.
-    if imaginaryArmySet[name] then
+    if StringStartsWith(ArmyBrains[index].Name, "Player") then
         table.insert(ScenarioInfo.HumanPlayers, index)
     end
 end

--- a/mods/coop/hook/lua/ui/lobby/lobbyComm.lua
+++ b/mods/coop/hook/lua/ui/lobby/lobbyComm.lua
@@ -1,9 +1,5 @@
 local MapUtil = import('/lua/ui/maputil.lua')
 
-function stringstarts(String, prefix)
-    return string.sub(String, 1, string.len(prefix)) == prefix
-end
-
 -- Add some extra magic to LaunchGame: a convenient time to hook pre-launch for all players.
 BaseLobbyComm = LobbyComm
 LobbyComm = Class(BaseLobbyComm) {
@@ -13,25 +9,18 @@ LobbyComm = Class(BaseLobbyComm) {
         -- Get the armies defined in the scenario.
         local scenarioArmies = MapUtil.ReallyGetArmies(scenarioInfo)
 
-        -- Map the human army-names to their entries in PlayerOptions.
-        local addedArmies = {
-            Player = 1,
-            Coop1 = 2,
-            Coop2 = 3,
-            Coop3 = 4
-        }
-
         local newPlayerOptions = {}
 
         -- We need to place each army at the index in PlayerOptions corresponding to the army's index in
         -- the map's army table. There are usually a bunch of other AI armies defined in the table,
         -- which we can probably ignore. I hope.
         -- Some dipshit decided not to standardise this.
+        local num = 1
         for armyIndex, armyName in scenarioArmies do
-            if armyName == "Player" or stringstarts(armyName, "Coop") then
+            if StringStartsWith(armyName, "Player") then
                 -- Shift each player to the slot that corresponds to their target army.
-                local ourArmyIndex = addedArmies[armyName]
-                newPlayerOptions[armyIndex] = gameInfo.PlayerOptions[ourArmyIndex]
+                newPlayerOptions[armyIndex] = gameInfo.PlayerOptions[num]
+                num = num + 1
             else
                 -- Voodoo copied from SinglePlayerLaunch.lua's stock logic for starting campaign.
                 local newAI = GetDefaultPlayerOptions(armyName)

--- a/mods/coop/hook/lua/ui/maputil.lua
+++ b/mods/coop/hook/lua/ui/maputil.lua
@@ -1,9 +1,28 @@
---- Return a fixed army set for coop games. Keep the old function available as we need it at
+--- Return all players' armies. Keep the old function available as we need it at
 -- launch-time.
 ReallyGetArmies = GetArmies
-
 function GetArmies(scenario)
-    return {"Player", "Coop1", "Coop2", "Coop3"}
+    local retArmies = {}
+
+    if scenario.Configurations.standard and scenario.Configurations.standard.teams then
+        -- find the "FFA" team
+        for index, teamConfig in scenario.Configurations.standard.teams do
+            if teamConfig.name and (teamConfig.name == 'FFA') then
+                for _, army in teamConfig.armies do
+                    if StringStartsWith(army, "Player") then
+                        table.insert(retArmies, army)
+                    end
+                end
+            end
+            break
+        end
+    end
+
+    if table.getn(retArmies) == 0 then
+        WARN("No starting armies defined in " .. scenario.file)
+    end
+
+    return retArmies
 end
 
 -- Make the map list show coop scenarios (only)
@@ -39,7 +58,7 @@ function GetStartPositions(scenario)
     doscript(scenario.save, saveData)
  
     local armyPositions = {}
-    local armiesOfInterest = GetArmies()
+    local armiesOfInterest = GetArmies(scenario)
     for k, armyName in armiesOfInterest do
         local armyTable = saveData.Scenario.Armies[armyName]
         armyPositions[armyName] = {0, 0}


### PR DESCRIPTION
Fixes #36 and  #37
It requires players' armies to be called `Player1, Player2, ... PlayerN`
Number of slots depends on the mission, no longer fixed to 4.

This can be added once the current missions are changed to work with
this, which means renaming `Coop` armies to `Player`

Later the campaign code will needs to be changed since it's using army
`Player` on many places, which should get renamed to `Player1` to keep
the naming of the armies sane.
