### PR TITLE
Ignore map filters

### DIFF
--- a/mods/coop/hook/lua/ui/dialogs/mapselect.lua
+++ b/mods/coop/hook/lua/ui/dialogs/mapselect.lua
@@ -1,3 +1,22 @@
+-- Ignore map filters from Game.prefs
+function InitFilters()
+    currentFilters = {}
+    local savedFilterState = {
+        map_obsolete = {
+            SelectedKey = 1 -- Enable obsolete map filtering by default.
+        }
+    }
+
+    -- savedFilterState is an array of tables of filter options
+    for filterKey, v in savedFilterState do
+        local filter = mapFilters[GetFilterIndex(filterKey)]
+        local factory = filter.FilterFactory
+        factory.SelectedKey = v.SelectedKey
+        factory.SelectedComparator = v.SelectedComparator
+        currentFilters[filter.FilterKey] = factory:Build()
+    end
+end
+
 local reallyCreateDialog = CreateDialog
 function CreateDialog(...)
     local ret = reallyCreateDialog(unpack(arg))


### PR DESCRIPTION
Map filters are not shown in coop since there are enough missions. But
game was loading saved filters from Gam.prefs file. This will make sure
that all maps will be shown.

Fixes https://github.com/FAForever/fa/issues/1117
