### PR TITLE
Improve BrainsCompareNumCategory

### DIFF
--- a/mods/coop/hook/lua/editor/OtherArmyUnitCountBuildConditions.lua
+++ b/mods/coop/hook/lua/editor/OtherArmyUnitCountBuildConditions.lua
@@ -169,19 +169,22 @@ end
 
 function BrainsCompareNumCategory( airBrain, targetBrains, numReq, category, compareType )
     local numUnits = 0
-
-    if targetBrains[1] == 'HumanPlayers' then
-        targetBrains = {}
-
-        local tblArmy = ListArmies()
-        for iArmy, strArmy in pairs(tblArmy) do
-            if ScenarioInfo.ArmySetup[strArmy].Human then
-                table.insert(targetBrains, ScenarioInfo.ArmySetup[strArmy].ArmyName)
+    
+    local targetBrainSet = {}
+    for _,brain in targetBrains do
+        if brain == 'HumanPlayers' then        
+            local tblArmy = ListArmies()
+            for _, strArmy in pairs(tblArmy) do
+                if ScenarioInfo.ArmySetup[strArmy].Human then
+                    targetBrainSet[ScenarioInfo.ArmySetup[strArmy].ArmyName] = true
+                end
             end
+        else
+            targetBrainSet[brain] = true
         end
     end
 
-    for _, brain in targetBrains do
+    for brain,_ in targetBrainSet do
         for _,testBrain in ArmyBrains do
             if testBrain.Name == brain then
                 numUnits = numUnits + testBrain:GetCurrentUnits(category)


### PR DESCRIPTION
I added the possibility to use HumanPlayers together with other armies and it doesn't need to be in the first position of the list anymore. I made sure to remove all duplicates aswell so you don't count units of armies multiple times. 
(for example: when you make an error like this -> TargetBrains={HumanPlayers, Player, Cybran}
