### PR TITLE
Add option to flag units so they cant be given

### DIFF
--- a/mods/coop/hook/lua/SimUtils.lua
+++ b/mods/coop/hook/lua/SimUtils.lua
@@ -1,0 +1,12 @@
+--- Filter out units that were set in the script that they can't be given to other players
+local oldTransferUnitsOwnership = TransferUnitsOwnership
+function TransferUnitsOwnership(units, ToArmyIndex)
+    if not units then return end
+    local toGiveUnits = {}
+    for _, v in units do
+        if v.CanBeGiven then
+            table.insert(toGiveUnits, v)
+        end
+    end
+    oldTransferUnitsOwnership(toGiveUnits, ToArmyIndex)
+end

--- a/mods/coop/hook/lua/sim/Unit.lua
+++ b/mods/coop/hook/lua/sim/Unit.lua
@@ -1,0 +1,11 @@
+local oldUnit = Unit
+Unit = Class(oldUnit) {
+    OnCreate = function(self)
+        oldUnit.OnCreate(self)
+        self.CanBeGiven = true
+    end,
+
+    SetCanBeGiven = function(self, val)
+        self.CanBeGiven = val
+    end,
+}


### PR DESCRIPTION
This allows to flag units with `unit:SetCanBeGiven(false)` to prevent
players from giving them to other players, but at the same time leave an
option for the script to give the units. Since the script can uses a
function in ScenarioFramework.GiveUnitToArmy
Fixes #75