### PR TITLE
Don't mess with line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*   text=auto
+*   text=false


### PR DESCRIPTION
Git changes CRLF to LF on checkout even if the original file *should* be CRLF.
This change makes sure that Git does not mess with line endings.