### PR TITLE
Add support for setting the difficulty via cmd line argument

### DIFF
--- a/mods/coop/hook/lua/ui/lobby/lobby.lua
+++ b/mods/coop/hook/lua/ui/lobby/lobby.lua
@@ -49,4 +49,8 @@ function CreateUI()
         end
         TryLaunch(false)
     end
+
+    -- Get the difficulty option sent from the client
+    local num = tonumber(GetCommandLineArg("/difficulty", 1)[1] or 3)
+    SetGameOption('Difficulty', num, true)
 end


### PR DESCRIPTION
Client can start the game with "/difficulty 1-3" and the lobby option will change accordingly
easy 1, medium 2, hard 3